### PR TITLE
update table schema, refactor db logging and error handling

### DIFF
--- a/database/migrations/001.do.sql
+++ b/database/migrations/001.do.sql
@@ -1,10 +1,11 @@
 CREATE TABLE snapshots (
     id integer DEFAULT nextval('snapshots_table_id_seq'::regclass) PRIMARY KEY,
-    "exchangeName" text NOT NULL,
-    "totalPrice" numeric,
-    "tokenAmount" numeric NOT NULL,
-    "tokenSymbol" character varying(5) NOT NULL,
-    "errorMessage" text,
+    exchange_name text NOT NULL,
+    total_price numeric,
+    token_amount numeric NOT NULL,
+    token_symbol character varying(5) NOT NULL,
+    error_message text,
+    is_sell boolean NOT NULL,
     timestamp bigint NOT NULL,
-    "batchTimestamp" bigint NOT NULL
+    batch_timestamp bigint NOT NULL
 );

--- a/handler.js
+++ b/handler.js
@@ -102,30 +102,24 @@ module.exports = {
 
     // don't use Promise.all.. we don't want these to run concurrently
     // calls are intentionally staggered to avoid API rate limits
+    let db
     try {
       await doWorkForPriceLevel(0)
       await doWorkForPriceLevel(1)
       await doWorkForPriceLevel(2)
-      initDb()
-        .then(db => {
-          Snapshot.createSnapshots(db, snapshots).then(arr => {
-            console.log(`successfully inserted ${arr.length} rows`)
-            if (callback) {
-              callback(null, snapshots)
-            }
-            db.end()
-          })
-        })
-        .catch(e => {
-          console.log('db connection failure', e.message)
-          if (callback) {
-            callback(e, null)
-          }
-        })
+      db = await initDb()
+      const createdSnapshots = await Snapshot.createSnapshots(db, snapshots)
+      console.log(`successfully inserted ${createdSnapshots.length} rows`)
+      if (callback) {
+        callback(null, snapshots)
+      }
+      db.end()
     } catch (error) {
+      console.error(error)
       if (callback) {
         callback(error, null)
       }
+      db.end()
     }
   },
   sellPriceSnapshot: async (event, context, callback) => {
@@ -170,30 +164,24 @@ module.exports = {
 
     // don't use Promise.all.. we don't want these to run concurrently
     // calls are intentionally staggered to avoid API rate limits
+    let db
     try {
       await doWorkForPriceLevel(0)
       await doWorkForPriceLevel(1)
       await doWorkForPriceLevel(2)
-      initDb()
-        .then(db => {
-          Snapshot.createSnapshots(db, snapshots).then(arr => {
-            console.log(`successfully inserted ${arr.length} rows`)
-            if (callback) {
-              callback(null, snapshots)
-            }
-            db.end()
-          })
-        })
-        .catch(e => {
-          console.log('db connection failure', e.message)
-          if (callback) {
-            callback(e, null)
-          }
-        })
+      db = await initDb()
+      const createdSnapshots = await Snapshot.createSnapshots(db, snapshots)
+      console.log(`successfully inserted ${createdSnapshots.length} rows`)
+      if (callback) {
+        callback(null, snapshots)
+      }
+      db.end()
     } catch (error) {
+      console.error(error)
       if (callback) {
         callback(error, null)
       }
+      db.end()
     }
   },
 }


### PR DESCRIPTION
The tool that we're using for migrations as part of CI, postgrator, checks the MD5 hash of the migration before running it. I got the changes in this PR working locally by deleting the row that Postgrator checks in a table called `schemaversion`. The easiest solution for the deployed AWS table might just be to drop the entire DB and start fresh. If this PR gets merged as is, then the `yarn db:migrate` step in CI will fail because I changed the table schema and the MD5 hash won't match what's in table `schemaversion`.